### PR TITLE
Remove zio's interop-future

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -768,7 +768,6 @@
 - zengularity/benji
 - zengularity/query-monad
 - zio/interop-cats
-- zio/interop-future
 - zio/interop-guava
 - zio/interop-java
 - zio/interop-monix


### PR DESCRIPTION
The project is archived hence it doesn't make sense to keep updating its dependencies.