### PR TITLE
Add avdv/play-json-refined, remove avdv/scalals

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -71,7 +71,7 @@
 - avast/datadog4s
 - avast/scala-server-toolkit
 - avast/slog4s
-- avdv/scalals
+- avdv/play-json-refined
 - AVSystem/scala-commons
 - azavea/franklin
 - azavea/stac4s


### PR DESCRIPTION
Temporarily remove avdv/scalals again -- it depends on a custom scala-native library which is not available publicly.