### PR TITLE
Remove zio-interop-java due to archiving

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -945,7 +945,6 @@
 - zengularity/query-monad
 - zio/interop-cats
 - zio/interop-guava
-- zio/interop-java
 - zio/interop-monix
 - zio/interop-reactive-streams
 - zio/interop-scalaz


### PR DESCRIPTION
The project has been ingested into main repo, hence this one has been archived.