### PR TITLE
Add Scapegoat repos to Scala Steward

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -774,6 +774,8 @@
 - sksamuel/avro4s
 - sksamuel/elastic4s
 - sksamuel/pulsar4s
+- sksamuel/sbt-scapegoat
+- sksamuel/scapegoat
 - Slakah/fastparse-parsers
 - Slakah/slakah.github.io
 - Slakah/uritemplate4s


### PR DESCRIPTION
It would be great to have Scapegoat projects included in Scala Steward.
@sksamuel has approved this - https://github.com/sksamuel/scapegoat/issues/280