### PR TITLE
Add scalameta repos back in

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -745,6 +745,13 @@
 - scalabin-no/http4s-directives
 - scalacenter/sbt-scalafix
 - scalacenter/scalafix
+- scalameta/mdoc
+- scalameta/metabrowse
+- scalameta/metals
+- scalameta/munit
+- scalameta/sbt-scalafmt
+- scalameta/scalafmt
+- scalameta/scalameta
 - scalapb/common-protos
 - scalapb/protobuf-scala-runtime
 - scalapb/protoc-bridge


### PR DESCRIPTION
In #196 we mentioned we hoped to add these back in. Now that we have the ability to control how often the prs are sent in we'd love to add the scalameta repos back in. Confirmed with @olafurpg.