### PR TITLE
Add repo weso/shex-lite to repos-github.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -987,6 +987,7 @@
 - weso/shex-s
 - weso/srdf
 - weso/utils
+- weso/shex-lite
 - wvlet/airframe
 - X9Developers/block-explorer
 - xerial/sbt-pack


### PR DESCRIPTION
Adds the repository `weso/shex-lite` to the file repos-github.md in line 990