### PR TITLE
Add codacy/codacy-analysis-cli to repos-github.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -209,6 +209,7 @@
 - circe/circe-yaml
 - CleverCloud/akka-warp10-scala-client
 - clovellytech/http4s-modules
+- codacy/codacy-analysis-cli
 - comcast/ip4s
 - concrete-cp/concrete
 - concrete-cp/cspom


### PR DESCRIPTION
We want try to use Scala Steward at @codacy.
Thank you in advance if you decide to merge the PR.

Lorenzo