### PR TITLE
Remove protenus repos (forks of scaldi) and add scaldi proper repos

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -719,9 +719,6 @@
 - profunktor/http4s-tracer
 - profunktor/redis4cats
 - proteinevolution/Toolkit
-- protenus/dipendi
-- protenus/dipendi-jsr330
-- protenus/dipendi-play
 - pureconfig/pureconfig
 - pwliwanow/fdb-pubsub
 - pwliwanow/foundationdb4s
@@ -833,6 +830,9 @@
 - scala/scala-parser-combinators
 - scala/scala-seed.g8
 - scala/scala-xml
+- scaldi/scaldi
+- scaldi/scaldi-jsr330
+- scaldi/scaldi-play
 - scanamo/scanamo
 - scaruby/scaruby
 - schrepfler/artemis


### PR DESCRIPTION
We've been working to get access to the scaldi github org for a while and it finally came through! This is the last step to get everything going over there, instead of the fork.

Thanks in advance