### PR TITLE
Update repos-github.md to change rchain/rchain to 9rb/rchain

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -15,6 +15,7 @@
 - 7mind/idealingua-v1
 - 7mind/izumi
 - 7mind/sbtgen
+- 9rb/rchain
 - abdolence/slack-morphism
 - afsalthaj/safe-string-interpolation
 - agourlay/cornichon
@@ -779,7 +780,6 @@
 - qbicsoftware/scark-cli
 - raboof/sbt-reproducible-builds
 - raster-foundry/granary
-- rchain/rchain
 - rcmartins/blinky
 - ReactiveMongo/Play-ReactiveMongo
 - ReactiveMongo/ReactiveMongo


### PR DESCRIPTION
We would like to receive the scala-steward PRs on the 9rb/rchain as opposed to the main rchain/rchain