### PR TITLE
un-rename scala-collection-compat

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -880,7 +880,7 @@
 - scala/scala-collection-laws
 - scala/scala-dist-smoketest
 - scala/scala-java8-compat
-- scala/scala-library-compat
+- scala/scala-collection-compat
 - scala/scala-module-dependency-sample
 - scala/scala-parallel-collections
 - scala/scala-parser-combinators


### PR DESCRIPTION
we decided to go back to the original name