### PR TITLE
Remove innFactory projects

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -459,8 +459,6 @@
 - IndiscriminateCoding/api4s
 - IndiscriminateCoding/jetty4s
 - ing-bank/baker
-- innFactory/akka-persistence-gcp-datastore
-- innFactory/bootstrap-play2
 - intracer/scalawiki
 - iRevive/fmq
 - iRevive/sbt-integration-env


### PR DESCRIPTION
We'll run Scala Steward in an private github action to access the secrets for tests. So we don't need the public repo way.