### PR TITLE
Removed vigoo/zio-aws

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1149,7 +1149,6 @@
 - vigoo/desert
 - vigoo/prox
 - vigoo/simpp
-- vigoo/zio-aws
 - vital-software/sbt-update-lines
 - vital-software/sbt-yourkit-external
 - vital-software/scala-redox


### PR DESCRIPTION
as it now runs Scala Steward as a GitHub Action