### PR TITLE
Add rewards-network/pure-aws to repos.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -848,6 +848,7 @@
 - reibitto/command-center
 - reibitto/podpodge
 - rememberthemilk/akka-amqp
+- rewards-network/pure-aws
 - rpiaggio/crystal
 - rpiaggio/log4cats-loglevel
 - rpiaggio/meal


### PR DESCRIPTION
This adds pure-aws, a new AWS client wrapper library from Rewards Network, to the list of repos managed by scala steward in `repos.md`. Thanks again for Scala Steward; we use it a lot internally and are happy to be publishing our first public library soon that uses it :)