### PR TITLE
Add mutation-testing-elements and weapon-regex

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1057,7 +1057,9 @@
 - stephennancekivell/scalatest-json
 - stripe/agate
 - stripe/dagon
+- stryker-mutator/mutation-testing-elements
 - stryker-mutator/stryker4s
+- stryker-mutator/weapon-regex
 - sullis/alpakka-jms-example
 - sullis/java-scala-interop-examples
 - sullis/jms-testkit


### PR DESCRIPTION
Mutation-testing-elements is a library to create metrics from results of a mutation testing framework. Weapon-regeX is a regex parser and mutator library.

@fthomas mutation-testing-library is a monorepo, with the sbt project that I want scala-steward to update in the `packages/mutation-testing-metrics-scala` subfolder. Will scala-steward detect that automatically or will I have to configure the `buildRoots`?