### PR TITLE
add jcouyang/dhall-generic

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -521,6 +521,7 @@
 - japgolly/univeq
 - jatcwang/doobieroll
 - jatcwang/scalafix-named-params
+- jcouyang/dhall-generic
 - jcouyang/jujiu
 - jcouyang/zhuyu
 - jcranky/godmode


### PR DESCRIPTION
thanks @fthomas
the infinite loop should be fixed at https://github.com/jcouyang/dhall-generic/commit/16a9207dbdaee5fc47a47ff4f721b794a046c0ae
the cause is because dhall-generic recursively depends on itself in sbt plugin, and then mergify automatically merge trigger deployment
ignoring dhall-generic should be able to prevent scala-steward recursive update the version in plugin