### PR TITLE
Replace stevedlawrence/daffodil with apache/daffodil

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -69,6 +69,7 @@
 - AndyKirsch/ScalaStewardIssueRepro
 - an-tex/sc8s
 - ant8e/sbt-i18n
+- apache/daffodil
 - apimorphism/telegramium
 - asachdeva/cats-sandbox
 - asachdeva/fpinsscala
@@ -1090,7 +1091,6 @@
 - srenault/sre-api
 - sritchie/scala-rl
 - stephennancekivell/scalatest-json
-- stevedlawrence/daffodil
 - stripe/agate
 - stripe/dagon
 - stryker-mutator/mutation-testing-elements


### PR DESCRIPTION
The stevedlawrence fork was a test used to propose the use of Scala
Steward to the Apache Daffodil developers. We have agreed that we should
enable this for the main apache/daffodil repo.