### PR TITLE
Adding other guardrail repos

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -468,6 +468,12 @@
 - guardian/price-migration-engine
 - guardian/support-service-lambdas
 - guardrail-dev/guardrail
+- guardrail-dev/guardrail-maven-plugin
+- guardrail-dev/guardrail-sample-gradle-http4s-zio
+- guardrail-dev/guardrail-sample-gradle-springmvc
+- guardrail-dev/guardrail-sample-maven-dropwizard
+- guardrail-dev/guardrail-sample-sbt-akkahttp
+- guardrail-dev/guardrail-sample-sbt-http4s-zio
 - guardrail-dev/sbt-guardrail
 - guizmaii/safe-libphonenumber
 - guizmaii/scala-nimbus-jose-jwt


### PR DESCRIPTION
Track dependencies in [guardrail starter repos](https://github.com/topics/guardrail-sample), as well as the dependencies for the guardrail-maven-plugin (🎉 maven support!)