### PR TITLE
Remove vital-software repos

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1288,8 +1288,6 @@
 - vigoo/desert
 - vigoo/prox
 - vigoo/simpp
-- vital-software/sbt-update-lines
-- vital-software/sbt-yourkit-external
 - VladKopanev/cats-saga
 - VladKopanev/zio-saga
 - VladPodilnyk/d4s-example


### PR DESCRIPTION
These are no longer required, thanks for the service!

(You can verify I'm an org member at https://github.com/orgs/vital-software/people)