### PR TITLE
Add guardian/payment-failure-comms to repos list

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -490,6 +490,7 @@
 - guardian/invoicing-api
 - guardian/manage-help-content-publisher
 - guardian/members-data-api
+- guardian/payment-failure-comms
 - guardian/price-migration-engine
 - guardian/support-service-lambdas
 - guardian/zuora-6for6-modifier


### PR DESCRIPTION
This PR add `guardian/payment-failure-comms` to the repos list