### PR TITLE
Add coursier/jni-utils

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -253,6 +253,7 @@
 - coursier/echo
 - coursier/http-server
 - coursier/interface
+- coursier/jni-utils
 - coursier/sbt-coursier
 - coursier/sbt-cs-publish
 - coursier/sbt-launcher


### PR DESCRIPTION
That lives [here](https://github.com/coursier/jni-utils).