### PR TITLE
Remove wvlet/sbt-airframe

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1469,7 +1469,6 @@
 - wiringbits/scala-webapp-template
 - wiringbits/sjs-material-ui-facade
 - wvlet/airframe
-- wvlet/sbt-airframe
 - wvlet/wvlet
 - X9Developers/block-explorer
 - xencura/kagera


### PR DESCRIPTION
sbt-airframe has moved to a subfolder of wvlet/airframe. Thanks for adding `buildRoots` configuration. 
https://github.com/wvlet/airframe/blob/master/.scala-steward.conf#L1