### PR TITLE
Remove cr-org/neutron

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -271,7 +271,6 @@
 - crealytics/spark-excel
 - criteo/cuttle
 - criteo/lolhttp
-- cr-org/neutron
 - d2a4u/meteor
 - d2a4u/sqs4s
 - d10xa/jadd


### PR DESCRIPTION
So that Steward does not get confused with https://neutron.profunktor.dev/, which started as a fork of the former (which I initially created at my previous job).