### PR TITLE
Remove repos breaking ToS

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1566,7 +1566,6 @@
 - wiringbits/wiringbits-webapp-utils
 - wvlet/airframe
 - wvlet/wvlet
-- X9Developers/stakenet-orderbook
 - xencura/kagera
 - xerial/sbt-pack
 - xerial/sbt-sonatype

--- a/repos-github.md
+++ b/repos-github.md
@@ -1566,8 +1566,6 @@
 - wiringbits/wiringbits-webapp-utils
 - wvlet/airframe
 - wvlet/wvlet
-- X9Developers/block-explorer
-- X9Developers/eth-indexer
 - X9Developers/stakenet-orderbook
 - xencura/kagera
 - xerial/sbt-pack


### PR DESCRIPTION
Arguably stakenet-orderbook also falls into the category of crypto but I didn't look at it close.

ref. https://github.com/scala-steward-org/repos/pull/917