### PR TITLE
ci: re-add the chief-of-state/chief-of-state repo

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1619,3 +1619,4 @@
 - zouzias/spark-lucenerdd
 - zzvara/spark-disqus
 - zzvara/spark-youtube
+- chief-of-state/chief-of-state


### PR DESCRIPTION
@exoego. I observed that repo was removed from scala-steward and I would like to bring back now. I added the previous one. It is not a fork but rather a copy because I am no longer at Namely and since I am the lead engineer and the maintenance of it is kind of in jeopardy after discussion with management l decided to have that copy and prepare for the eventual.