### PR TITLE
remove typelevel/sbt-catalysts add kailuowang/sbt-catalysts

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -657,6 +657,7 @@
 - jxnu-liguobin/scala-macro-tools
 - kailuowang/henkan
 - kailuowang/mau
+- kailuowang/sbt-catalysts
 - kaizen-solutions/virgil
 - katlasik/functionmeta
 - kcrypt/scala-biginteger
@@ -1503,7 +1504,6 @@
 - typelevel/mouse
 - typelevel/munit-cats-effect
 - typelevel/paiges
-- typelevel/sbt-catalysts
 - typelevel/sbt-typelevel
 - typelevel/scalacheck
 - typelevel/scalacheck-effect


### PR DESCRIPTION
`typelevel/sbt-catalysts` was archived. I'll main a folk from now on.