### PR TITLE
`main` is no longer the default http4s branch

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -583,7 +583,6 @@
 - hseeberger/slf4s
 - http4s/blaze
 - http4s/hpack
-- http4s/http4s
 - http4s/http4s.g8
 - http4s/http4s-armeria
 - http4s/http4s-crypto
@@ -593,6 +592,7 @@
 - http4s/http4s-jdk-http-client
 - http4s/http4s-netty
 - http4s/http4s-session
+- http4s/http4s:main
 - http4s/http4s:series/0.22
 - http4s/http4s:series/0.23
 - http4s/rho


### PR DESCRIPTION
Better to list all the branches explicitly? Or now that series/0.23 is the default should we remove the `:series/0.23` instead?