### PR TITLE
Remove nationalarchives repos.

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -865,9 +865,6 @@
 - nafg/slick-migration-api-flyway
 - namely/chief-of-state
 - naoh87/lettucef
-- nationalarchives/tdr-checksum
-- nationalarchives/tdr-consignment-api
-- nationalarchives/tdr-transfer-frontend
 - navicore/akka-eventhubs
 - navicore/ehtail
 - navicore/lots-of-names


### PR DESCRIPTION
We're going to run Scala Steward locally using our own git users so we
don't need these any more.
