### PR TITLE
adding kailuowang/sbt-catalysts back

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -662,6 +662,7 @@
 - jxnu-liguobin/scala-macro-tools
 - kailuowang/henkan
 - kailuowang/mau
+- kailuowang/sbt-catalysts
 - kaizen-solutions/virgil
 - katlasik/functionmeta
 - kcrypt/scala-biginteger


### PR DESCRIPTION
trying to add kailuowang/sbt-catalysts back. it seems that scala-steward mistakenly believes that this repo is archived and removed it. It was the repo `typelevel/sbt-catalysts` from which `kailuowang/sbt-catalysts` forked that was archived. I am giving another try to see if this issue is resolved.