### PR TITLE
Add blindnet-io/blindsend-server

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -150,6 +150,7 @@
 - blackdoor/jose
 - blemale/scaffeine
 - blended-zio/blended-zio
+- blindnet-io/blindsend-server
 - bot4s/telegram
 - bot4s/zmatrix
 - BotTech/scala2plantuml


### PR DESCRIPTION
Server code of [blindsend](https://blindsend.io/), an open source web app for end-to-end encrypted file sharing.