### PR TITLE
remove broadinstitute/sam

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -160,7 +160,6 @@
 - broadinstitute/cromwell
 - broadinstitute/leonardo-cron-jobs
 - broadinstitute/rawls
-- broadinstitute/sam
 - broadinstitute/workbench-libs
 - brsyuksel/xurl
 - buildo/retro


### PR DESCRIPTION
We are using the scala-steward-action internally now.

(Reverting https://github.com/scala-steward-org/repos/pull/982)