### PR TITLE
Remove the `series/0.22` branch of `http4s` from updating

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -609,7 +609,6 @@
 - http4s/http4s-session
 - http4s/http4s-tomcat
 - http4s/http4s:main
-- http4s/http4s:series/0.22
 - http4s/http4s:series/0.23
 - http4s/module.g8
 - http4s/rho


### PR DESCRIPTION
We are planning to stop actively developing the 0.22 series (https://github.com/http4s/http4s/issues/6331).