### PR TITLE
Add monix/newtypes, update monix/monix

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -852,12 +852,12 @@
 - molikto/medit
 - monadless/monadless
 - monix/minitest
-- monix/monix
 - monix/monix:series/3.x
 - monix/monix:series/4.x
 - monix/monix-bio
 - monix/monix-connect
 - monix/monix-kafka
+- monix/newtypes
 - monksy/serialization-checker
 - msgpack/msgpack-java
 - mvillafuertem/akka-zio

--- a/repos-github.md
+++ b/repos-github.md
@@ -852,7 +852,8 @@
 - molikto/medit
 - monadless/monadless
 - monix/minitest
-- monix/monix
+- monix/monix:series/3.x
+- monix/monix:series/4.x
 - monix/monix-bio
 - monix/monix-connect
 - monix/monix-kafka

--- a/repos-github.md
+++ b/repos-github.md
@@ -852,6 +852,7 @@
 - molikto/medit
 - monadless/monadless
 - monix/minitest
+- monix/monix
 - monix/monix:series/3.x
 - monix/monix:series/4.x
 - monix/monix-bio


### PR DESCRIPTION
- Adds `monix/newtypes`
- Modifies `monix/monix` to maintain both `series/3.x` and `series/4.x` (multi-branch support)